### PR TITLE
Feature - Installation only scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,31 @@ A library with Make targets, Ansible playbooks, Jinja templates (and more) desig
 
 ## Getting Started
 
-You can adopt AWS Code Habits in two ways:
+You can adopt AWS Code Habits in several ways.
+On a terminal, on your project's root directory, execute one of the following commands:
 
-### 1. Remote (using Git Submodules)
-On a terminal, on your project root directory, execute the following on Ubuntu:
+### 1. Remote (using Git Submodules, initialize all files)
 
 ```bash
 curl -sL https://raw.githubusercontent.com/awslabs/aws-code-habits/main/scripts/remote/init.sh | bash
 ```
 
-### 2. Standalone (without Git Submodules)
- On a terminal, on your project root directory, execute the following on Ubuntu:
+### 2. Remote (using Git Submodules, installation only)
+
+```bash
+curl -sL https://raw.githubusercontent.com/awslabs/aws-code-habits/main/scripts/remote/install.sh | bash
+```
+
+### 3. Standalone (without Git Submodules, initialize all files)
 
 ```bash
 curl -sL https://raw.githubusercontent.com/awslabs/aws-code-habits/main/scripts/standalone/init.sh | bash
+```
+
+### 4. Standalone (without Git Submodules, installation only)
+
+```bash
+curl -sL https://raw.githubusercontent.com/awslabs/aws-code-habits/main/scripts/standalone/install.sh | bash
 ```
 
 

--- a/doc/habits.yaml
+++ b/doc/habits.yaml
@@ -26,20 +26,31 @@ title: AWS Code Habits
 description: A library with Make targets, Ansible playbooks, Jinja templates (and more) designed to boost common software development tasks and enhance governance.
 
 getting_started: |-
-  You can adopt AWS Code Habits in two ways:
+  You can adopt AWS Code Habits in several ways.
+  On a terminal, on your project's root directory, execute one of the following commands:
 
-  ### 1. Remote (using Git Submodules)
-  On a terminal, on your project root directory, execute the following on Ubuntu:
+  ### 1. Remote (using Git Submodules, initialize all files)
 
   ```bash
   curl -sL https://raw.githubusercontent.com/awslabs/aws-code-habits/main/scripts/remote/init.sh | bash
   ```
 
-  ### 2. Standalone (without Git Submodules)
-   On a terminal, on your project root directory, execute the following on Ubuntu:
+  ### 2. Remote (using Git Submodules, installation only)
+
+  ```bash
+  curl -sL https://raw.githubusercontent.com/awslabs/aws-code-habits/main/scripts/remote/install.sh | bash
+  ```
+
+  ### 3. Standalone (without Git Submodules, initialize all files)
 
   ```bash
   curl -sL https://raw.githubusercontent.com/awslabs/aws-code-habits/main/scripts/standalone/init.sh | bash
+  ```
+
+  ### 4. Standalone (without Git Submodules, installation only)
+
+  ```bash
+  curl -sL https://raw.githubusercontent.com/awslabs/aws-code-habits/main/scripts/standalone/install.sh | bash
   ```
 
 prerequisites:

--- a/scripts/remote/install.sh
+++ b/scripts/remote/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+git submodule add --name habits -b main https://github.com/awslabs/aws-code-habits.git habits
+cp habits/scripts/Makefile Makefile
+make habits/install
+echo "AWS Code Habits installed successfully!"

--- a/scripts/standalone/install.sh
+++ b/scripts/standalone/install.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+git clone --branch=main --depth=1 https://github.com/awslabs/aws-code-habits.git habits
+rm -rf habits/.git
+cp habits/scripts/Makefile Makefile
+make habits/install
+echo 'habits/' >> .gitignore
+echo "AWS Code Habits installed successfully!"


### PR DESCRIPTION
## 🧠 Pull Request

### Changes

* Allow the installation of AWS Code Habits without initializing all files, allowing the user to decide when such action is most suitable.

### Type of change

* New feature

## Why

* Very often, on non-GitHub projects, some files such as pull_request, workflows, are not interesting to have, and avoiding the unnecessary creation of such files would improve the user experience.

## How

* Simply don't execute `make habits/init` in one of the scripts.