### PR TITLE
Use openssl to generate random string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,7 @@ export HABITS = $(WORKSPACE)
 include $(WORKSPACE)/tools.env
 
 include $(HABITS)/lib/make/Makefile
-include $(HABITS)/lib/make/ansible/Makefile
-include $(HABITS)/lib/make/pre-commit/Makefile
-include $(HABITS)/lib/make/doc/Makefile
+include $(HABITS)/lib/make/*/Makefile
 
 .PHONY: hygiene
 hygiene: doc/build pre-commit/run

--- a/lib/make/aws/cloudformation/Makefile
+++ b/lib/make/aws/cloudformation/Makefile
@@ -6,7 +6,7 @@
 STACK_ENVIRONMENT_NAME ?= $(STACK_NAME_PREFIX)-$(ENVIRONMENT)
 
 # Generate random unique 4-letter identifier
-CHANGE_SET_ID:=$(shell tr -dc A-Za-z0-9 </dev/urandom | head -c 4 ; echo '')
+CHANGE_SET_ID:=$(shell openssl rand -base64 4)
 CHANGE_SET_NAME ?= $(STACK_ENVIRONMENT_NAME)-$(CHANGE_SET_ID)
 
 .PHONY: aws/cloudformation/assert/variables


### PR DESCRIPTION
## 🧠 Pull Request

### Changes

* Fix the generation of random string.

### Type of change

* Bug fix

## Why

* Need to consider other OSes, architectures, which might not use `/dev/random` in favor of a more common solution, the `openssl` package for example.

## How (Optional)

* Use openssl instead to achieve the same goal.
