### PR TITLE
Add tflint/run rule

### DIFF
--- a/lib/make/tflint/Makefile
+++ b/lib/make/tflint/Makefile
@@ -19,6 +19,11 @@ ifeq ($(wildcard $(WORKSPACE)/.tflint.hcl),)
 	@tflint --init
 endif
 
+.PHONY: tflint/run
+## Run TFLINT
+tflint/run:
+	tflint .
+
 .PHONY: tflint/version
 ## Display TFLINT version
 tflint/version:

--- a/lib/make/tflint/Makefile
+++ b/lib/make/tflint/Makefile
@@ -22,7 +22,7 @@ endif
 .PHONY: tflint/run
 ## Run TFLINT
 tflint/run:
-	tflint .
+	@tflint .
 
 .PHONY: tflint/version
 ## Display TFLINT version


### PR DESCRIPTION
This is required for terraform/init. See https://github.com/awslabs/aws-code-habits/blob/2cb972c53a246c0d5cba8b4d2a0f22e604eb7008/lib/make/terraform/Makefile#L6
