### PR TITLE
fix: remove terraform-docs configuration

### DIFF
--- a/lib/make/terraform-docs/Makefile
+++ b/lib/make/terraform-docs/Makefile
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-export TERRAFORM_DOCS_TEMPLATE_YAML ?= $(WORKSPACE)/.devcontainer/files/.terraform-docs.yaml
 export TERRAFORM_DOCS_YAML ?= $(WORKSPACE)/doc/.terraform-docs.yaml
 export TERRAFORM_DOCS_OUTPUT ?= $(WORKSPACE)/doc/terraform-docs.md
 
@@ -17,20 +16,12 @@ terraform-docs/install:
 	@echo "terraform-docs installed successfully!"
 	@$(MAKE) --no-print-directory terraform-docs/version
 
-
-.PHONY: terraform-docs/init
-## Create initl configuration
-terraform-docs/init:
-ifneq ($(wildcard *.tf),)
-	@cp $(TERRAFORM_DOCS_TEMPLATE_YAML) $(TERRAFORM_DOCS_YAML)
-endif
-
 .PHONY: terraform-docs/build
 ## Build doc/terraform-docs.md with Terraform Docs
 terraform-docs/build:
 ifneq ($(wildcard *.tf),)
 	@echo "# Terraform" > Terraform.md
-	@terraform-docs --config $(TERRAFORM_DOCS_YAML) . >> Terraform.md
+	@terraform-docs markdown . >> Terraform.md
 endif
 
 .PHONY: terraform-docs/version


### PR DESCRIPTION
## 🧠 Pull Request

### Changes

Remove `terraform-docs/init` make target.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

## Why

Keeping simple the usage of `terraform-docs`.
