### PR TITLE
docs: add mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ The library has three parts:
 
 You add the library to a project as a Git submodule (or as a vendored copy) and include its Make targets from your own `Makefile`. It is intended for teams that want a shared, version-controlled set of development commands across many repositories.
 
+The following diagram shows how your project consumes the library:
+
+```mermaid
+flowchart LR
+    project["Your project"]
+    makefile["Your Makefile<br/>includes lib/make/*/*.mk<br/>and lib/make/*.mk"]
+    targets["make targets<br/>(terraform/plan, python/test, doc/build)"]
+    tools["Tools<br/>(Terraform, AWS CDK, Python, Node.js, Go)"]
+    ansible["Ansible playbooks<br/>(lib/ansible/)"]
+
+    project --> makefile
+    makefile -->|include .mk glob| targets
+    targets -->|run a tool directly| tools
+    targets -->|multi-step actions| ansible
+```
+
 ## Features
 
 - Run common tasks through consistent `make` targets across repositories.
@@ -285,6 +301,24 @@ Destructive targets are gated behind a confirmation prompt: `terraform/apply`, `
 You include the library's `.mk` files from your `Makefile`. Each `.mk` file under `lib/make/` defines targets for one tool or technology. Targets that perform multi-step actions, such as `doc/build` and `doc/init`, delegate to Ansible playbooks under `lib/ansible/`.
 
 `README.md` is generated. The `doc/build` target runs an Ansible playbook that renders the Jinja template `lib/ansible/templates/readme.j2` using the data in `doc/habits.yaml`, then writes the result to `README.md`.
+
+The following diagram shows the documentation render pipeline:
+
+```mermaid
+flowchart LR
+    cmd["make doc/build"]
+    target["doc/build target<br/>(lib/make/doc.mk)"]
+    playbook["Ansible playbook<br/>(lib/ansible/playbooks/doc/build.yaml)"]
+    data["doc/habits.yaml<br/>(source data)"]
+    template["readme.j2<br/>(lib/ansible/templates/)"]
+    readme["README.md<br/>(generated)"]
+
+    cmd --> target
+    target --> playbook
+    data --> playbook
+    template --> playbook
+    playbook -->|render| readme
+```
 
 ## Contributing
 

--- a/doc/habits.yaml
+++ b/doc/habits.yaml
@@ -36,6 +36,22 @@ overview: |-
 
   You add the library to a project as a Git submodule (or as a vendored copy) and include its Make targets from your own `Makefile`. It is intended for teams that want a shared, version-controlled set of development commands across many repositories.
 
+  The following diagram shows how your project consumes the library:
+
+  ```mermaid
+  flowchart LR
+      project["Your project"]
+      makefile["Your Makefile<br/>includes lib/make/*/*.mk<br/>and lib/make/*.mk"]
+      targets["make targets<br/>(terraform/plan, python/test, doc/build)"]
+      tools["Tools<br/>(Terraform, AWS CDK, Python, Node.js, Go)"]
+      ansible["Ansible playbooks<br/>(lib/ansible/)"]
+
+      project --> makefile
+      makefile -->|include .mk glob| targets
+      targets -->|run a tool directly| tools
+      targets -->|multi-step actions| ansible
+  ```
+
 features:
   - Run common tasks through consistent `make` targets across repositories.
   - Install and pin developer tools (Terraform, AWS CDK, Python, Node.js, Go, and more) through dedicated targets.
@@ -290,6 +306,24 @@ how_it_works: |-
   You include the library's `.mk` files from your `Makefile`. Each `.mk` file under `lib/make/` defines targets for one tool or technology. Targets that perform multi-step actions, such as `doc/build` and `doc/init`, delegate to Ansible playbooks under `lib/ansible/`.
 
   `README.md` is generated. The `doc/build` target runs an Ansible playbook that renders the Jinja template `lib/ansible/templates/readme.j2` using the data in `doc/habits.yaml`, then writes the result to `README.md`.
+
+  The following diagram shows the documentation render pipeline:
+
+  ```mermaid
+  flowchart LR
+      cmd["make doc/build"]
+      target["doc/build target<br/>(lib/make/doc.mk)"]
+      playbook["Ansible playbook<br/>(lib/ansible/playbooks/doc/build.yaml)"]
+      data["doc/habits.yaml<br/>(source data)"]
+      template["readme.j2<br/>(lib/ansible/templates/)"]
+      readme["README.md<br/>(generated)"]
+
+      cmd --> target
+      target --> playbook
+      data --> playbook
+      template --> playbook
+      playbook -->|render| readme
+  ```
 
 contributing: |-
   See [Contributing](CONTRIBUTING.md).


### PR DESCRIPTION
## What

Adds two Mermaid diagrams to the documentation to illustrate the library's structure and flow. GitHub renders ```mermaid fenced blocks natively.

### Diagrams added

1. **Overview** (`README.md` Overview section, sourced from `doc/habits.yaml`) — a flowchart showing how a consuming project includes habits via the `lib/make/*.mk` glob from its own `Makefile`, then invokes `make` targets that either run a tool directly (Terraform, AWS CDK, Python, Node.js, Go) or delegate to Ansible playbooks.
2. **How it works** (`README.md` How it works section, sourced from `doc/habits.yaml`) — a flowchart of the documentation render pipeline: `make doc/build` → the `doc/build` target → the Ansible playbook → `readme.j2` + `doc/habits.yaml` → the generated `README.md`.

### Generated README handling

`README.md` is generated from `doc/habits.yaml` via `lib/ansible/templates/readme.j2` (rendered by `make doc/build`), and is listed in `.prettierignore`. The diagrams were added to **both** the source of truth (`doc/habits.yaml`, inside the `overview` and `how_it_works` block scalars) and the generated `README.md`, so they survive the next `make doc/build`.

### Notes

- All Mermaid diagrams validated locally with mermaid-cli.
- Documentation style matches the existing AWS doc style (sentence-case headings, second person, no marketing language).
- Compliance files not modified.
- No branch protections or settings changed.
